### PR TITLE
[WIP] CI: setup github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,14 @@
+name: "continuous-integration"
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: jorelali/setup-elm@v2
+      with:
+        elm-version: 0.19.1
+    - run: node -v
+    - run: npm install
+    - run: npm run-script build

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,6 @@
   <body>
     <!-- JavaScript goes here -->
     <main></main>
-    <script src="/dist/elm.compiled.js"></script>
     <script src="/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
I tried adding a CI pipeline for elm-chorus using https://github.com/JorelAli/setup-elm but it fails due to this https://github.com/priyanshu0405/elm-chorus/runs/2159286939. But it works fine locally. What could be the issue?