### PR TITLE
Implemented Addons and Keyboard section in Help page

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -227,3 +227,41 @@ h2 {
 .markdown a:hover {
   color: #337ab7;
 }
+
+.markdown pre {
+  background-color: #f5f5f5;
+  padding: 12px;
+  border: 1px dashed #ccc;
+  border-radius: 4px;
+  font-size: 0.9em;
+  line-height: 10px;
+  color: #2b2f30;
+}
+
+.markdown p > code {
+  background-color: #f5f5f5;
+  padding: 2px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.markdown p > code:hover {
+  border: 1px solid #12b2e7;
+  border-radius: 4px;
+  color: #12b2e7;
+}
+
+.markdown li > code {
+  background-color: #f5f5f5;
+  padding: 2px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.markdown li > code:hover {
+  border: 1px solid #12b2e7;
+  border-radius: 4px;
+  color: #12b2e7;
+}

--- a/public/main.css
+++ b/public/main.css
@@ -219,6 +219,13 @@ h2 {
   border-bottom: 2px solid #f6f6f6;
 }
 
+.markdown h3 {
+  font-weight: 300;
+  font-size: 1.3em;
+  color: #666;
+  margin-bottom: 0;
+}
+
 .markdown a {
   text-decoration: none;
   color: #12b2e7;

--- a/src/Pages/Help/Addons.elm
+++ b/src/Pages/Help/Addons.elm
@@ -77,37 +77,12 @@ available. The [Add-Ons] page lists add-ons that are executable (eg. Global Sear
 
 audio/video content (eg. YouTube). Add-ons that provide lists can also be accessed via the [browser].
 
-Custom Add-on Search
----------
-Out of the box, Chorus includes search functionality for some of the more popular add-ons, this allows you to 
-
-search content provided by that add-on via the search page. For example you could type in "crazy cat videos" in 
-
-the search box and then on the search page, click "YouTube" to get a list of videos provided by YouTube on that 
-
-subject.
-
-If you wish to search content provided by an add-on that isn't included with Chorus, you can add your own 
-
-[custom add-on search] which tells Chorus how it can search for the content provided by that add-on.
-
-To add a custom search, you need to know what url the add-on is using internally to provide the search results. 
-
-This isn't always easy or obvious to find out and may involve looking through the add-on code or kodi logs to 
-
-determine the correct url to use. Chorus will substitute the token `[QUERY]` with the search term.
-
-### Examples of add-on search urls
-- YouTube: `plugin://plugin.video.youtube/search/?q=[QUERY]`
-- SoundCloud: `plugin://plugin.audio.soundcloud/search/query/?q=[QUERY]`
-- Radio: `plugin://plugin.audio.radio_de/stations/search/[QUERY]`
-- MixCloud: `plugin://plugin.audio.mixcloud/?mode=30&key=cloudcast&offset=0&query=[QUERY]`
 
 ### Contributing
 
 If you find a good custom add-on search that should be included in Chorus out of the box then you should 
 
-consider submitting a [pull request] for it. Look at the [SoundCloud module] as an example of the code structure. 
+consider submitting a [pull request] for it. 
 
 NOTE: Only add-ons that are in the official repository will accepted.
 
@@ -133,10 +108,8 @@ A few things that have been observed with using add-ons in Chorus
 
 [Add-Ons]: http://localhost:1234/addons
 [browser]: http://localhost:1234/browser
-[custom add-on search]: http://localhost:1234/settings/search
 [pull request]: https://github.com/xbmc/elm-chorus/pulls
 [settings page]: http://localhost:1234/settings/web
-[SoundCloud module]: https://github.com/xbmc/chorus2/blob/master/src/js/apps/addon/soundcloud/addon_soundcloud_app.js.coffee
 """
 
 

--- a/src/Pages/Help/Addons.elm
+++ b/src/Pages/Help/Addons.elm
@@ -2,8 +2,12 @@ module Pages.Help.Addons exposing (Model, Msg, Params, page)
 
 import Colors
 import Components.VerticalNavHelp
-import Element exposing (column, fill, fillPortion, row, spacingXY)
+import Element exposing (..)
 import Element.Background as Background
+import Element.Font as Font
+import Html exposing (Html)
+import Html.Attributes exposing (class)
+import Markdown exposing (..)
 import Spa.Document exposing (Document)
 import Spa.Generated.Route exposing (Route)
 import Spa.Page as Page exposing (Page)
@@ -58,6 +62,85 @@ subscriptions model =
 
 
 
+-- Markdown
+
+
+content : Html msg
+content =
+    Markdown.toHtml [ class "markdown" ] """
+
+# Add-on Support                  
+
+Chorus supports add-ons, but at a generic level. As each add-on does things differently, not all functionality will be 
+
+available. The [Add-Ons] page lists add-ons that are executable (eg. Global Search) or add-ons that provide a list of 
+
+audio/video content (eg. YouTube). Add-ons that provide lists can also be accessed via the [browser].
+
+Custom Add-on Search
+---------
+Out of the box, Chorus includes search functionality for some of the more popular add-ons, this allows you to 
+
+search content provided by that add-on via the search page. For example you could type in "crazy cat videos" in 
+
+the search box and then on the search page, click "YouTube" to get a list of videos provided by YouTube on that 
+
+subject.
+
+If you wish to search content provided by an add-on that isn't included with Chorus, you can add your own 
+
+[custom add-on search] which tells Chorus how it can search for the content provided by that add-on.
+
+To add a custom search, you need to know what url the add-on is using internally to provide the search results. 
+
+This isn't always easy or obvious to find out and may involve looking through the add-on code or kodi logs to 
+
+determine the correct url to use. Chorus will substitute the token `[QUERY]` with the search term.
+
+### Examples of add-on search urls
+- YouTube: `plugin://plugin.video.youtube/search/?q=[QUERY]`
+- SoundCloud: `plugin://plugin.audio.soundcloud/search/query/?q=[QUERY]`
+- Radio: `plugin://plugin.audio.radio_de/stations/search/[QUERY]`
+- MixCloud: `plugin://plugin.audio.mixcloud/?mode=30&key=cloudcast&offset=0&query=[QUERY]`
+
+### Contributing
+
+If you find a good custom add-on search that should be included in Chorus out of the box then you should 
+
+consider submitting a [pull request] for it. Look at the [SoundCloud module] as an example of the code structure. 
+
+NOTE: Only add-ons that are in the official repository will accepted.
+
+Enabling and disabling Add-ons
+---------
+Chorus provides a [settings page] for enabling and disabling add-ons, be aware that disabling certain add-ons may 
+
+have adverse effects so use with care.  
+
+Known issues and limitations
+---------
+A few things that have been observed with using add-ons in Chorus
+- You cannot download add-on content.
+- You can only play add-on content via Kodi, it cannot be streamed to the web browser.
+- Adding a single add-on media to the playlist often results in the playlist entry having a weird title or missing a 
+
+  title altogether. Adding an add-on folder seems to populate it correctly. This appears to be an issue with the 
+    
+  Kodi API.
+
+- Some add-ons won't work at all, this should be raised up with the add-on author.
+** **       
+
+[Add-Ons]: http://localhost:1234/addons
+[browser]: http://localhost:1234/browser
+[custom add-on search]: http://localhost:1234/settings/search
+[pull request]: https://github.com/xbmc/elm-chorus/pulls
+[settings page]: http://localhost:1234/settings/web
+[SoundCloud module]: https://github.com/xbmc/chorus2/blob/master/src/js/apps/addon/soundcloud/addon_soundcloud_app.js.coffee
+"""
+
+
+
 -- VIEW
 
 
@@ -65,9 +148,12 @@ view : Model -> Document Msg
 view model =
     { title = "Help.Addons"
     , body =
-        Components.VerticalNavHelp.view
-            model.route
-            ++ [ column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.background ]
-                    []
-               ]
+        [ row [ Element.height fill, Element.width fill ]
+            [ column [ Element.height fill, Element.width (fillPortion 3), scrollbarY ] (Components.VerticalNavHelp.view model.route)
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.white, padding 40 ]
+                [ el [ Font.color (rgb255 0 0 0) ] (Element.html content)
+                ]
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.greyscaleMercury, padding 40 ] []
+            ]
+        ]
     }

--- a/src/Pages/Help/Keyboard.elm
+++ b/src/Pages/Help/Keyboard.elm
@@ -119,19 +119,18 @@ Key "" = Full screen
 
 Browser
 ---------
-The keyboard controls the browser only. When the [remote] is open the keys will control only Kodi.
+The keyboard controls the browser only. When the remote is open the keys will control only Kodi.
 
 Both
 ---------
-Keyboard commands are executed in Kodi and in the browser. When the [remote] is open the keys will control only 
+Keyboard commands are executed in Kodi and in the browser. When the remote is open the keys will control only 
 
 Kodi. NOTE: Many commands are shared by both the browser and Kodi. Eg. Backspace.
 
 ** **       
 
-[remote]: http://localhost:1234/#remote
 [settings page]: http://localhost:1234/settings/web
-[Got improvements to add? click here]:https://github.com/xbmc/chorus2/blob/master/src/js/apps/input/input_app.js.coffee
+[Got improvements to add? click here]:https://github.com/xbmc/elm-chorus
 """
 
 

--- a/src/Pages/Help/Keyboard.elm
+++ b/src/Pages/Help/Keyboard.elm
@@ -2,8 +2,12 @@ module Pages.Help.Keyboard exposing (Model, Msg, Params, page)
 
 import Colors
 import Components.VerticalNavHelp
-import Element exposing (column, fill, fillPortion, row, spacingXY)
+import Element exposing (..)
 import Element.Background as Background
+import Element.Font as Font
+import Html exposing (Html)
+import Html.Attributes exposing (class)
+import Markdown exposing (..)
 import Spa.Document exposing (Document)
 import Spa.Generated.Route exposing (Route)
 import Spa.Page as Page exposing (Page)
@@ -58,6 +62,80 @@ subscriptions model =
 
 
 
+-- Markdown
+
+
+content : Html msg
+content =
+    Markdown.toHtml [ class "markdown" ] """
+
+# Key Binds                     
+
+You can use your keyboard to control Kodi, this is the default setting but you can change what the keyboard 
+
+controls on the [settings page]. The available options are:
+
+Kodi
+---------
+The keyboard controls Kodi and default keyboard interaction with the browser is disabled. (eg. using up and down 
+
+arrows to scroll a page). [Browser command] = [Kodi action].
+
+~~~
+Cursor LEFT = Direction LEFT
+
+Cursor RIGHT = Direction RIGHT
+
+Cursor UP = Direction UP
+
+Cursor DOWN = Direction DOWN
+
+BACKSPACE = Back
+
+ENTER = Select
+
+TAB = Close
+
+SPACE BAR = Play/Pause
+
+Key "C" = Context menu
+
+Key "+" = Volume Up
+
+Key "-" = Volume Down
+
+Key "X" = Stop
+
+Key "T" = Toggle subtitles
+
+Key ">" = Play Next
+
+Key "<" = Play Prev
+
+Key "" = Full screen
+
+~~~
+[Got improvements to add? click here]
+
+Browser
+---------
+The keyboard controls the browser only. When the [remote] is open the keys will control only Kodi.
+
+Both
+---------
+Keyboard commands are executed in Kodi and in the browser. When the [remote] is open the keys will control only 
+
+Kodi. NOTE: Many commands are shared by both the browser and Kodi. Eg. Backspace.
+
+** **       
+
+[remote]: http://localhost:1234/#remote
+[settings page]: http://localhost:1234/settings/web
+[Got improvements to add? click here]:https://github.com/xbmc/chorus2/blob/master/src/js/apps/input/input_app.js.coffee
+"""
+
+
+
 -- VIEW
 
 
@@ -65,9 +143,12 @@ view : Model -> Document Msg
 view model =
     { title = "Help.Keyboard"
     , body =
-        Components.VerticalNavHelp.view
-            model.route
-            ++ [ column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.background ]
-                    []
-               ]
+        [ row [ Element.height fill, Element.width fill ]
+            [ column [ Element.height fill, Element.width (fillPortion 3), scrollbarY ] (Components.VerticalNavHelp.view model.route)
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.white, padding 40 ]
+                [ el [ Font.color (rgb255 0 0 0) ] (Element.html content)
+                ]
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.greyscaleMercury, padding 40 ] []
+            ]
+        ]
     }


### PR DESCRIPTION
Hi @razzeee,
I have implemented the Addons & Keyboards section in the Help Page.
	
While implementing the sections, I noticed that at multiple places the links have to be updated in the sections. (for example, the remote hasn't been implemented yet, but its link has been referenced in the keyboard section).

I think we can make the relevant changes later on as well - as per need, since making changes in it involve trivial steps. Please let me know if any changes are required.

| | Chorus 2  | Elm Chorus |
| ------------- | ------------- | ------------- |
| Keyboards | ![Screenshot from 2022-05-03 11-08-06](https://user-images.githubusercontent.com/18377109/166409287-237fd91f-9242-4874-998a-200fa03ca1dd.png) | ![Screenshot from 2022-05-03 11-07-55](https://user-images.githubusercontent.com/18377109/166409304-a883dd4b-17fb-46a8-a02e-a877ba68850a.png)  |
| Addons | ![Screenshot from 2022-05-03 11-16-52](https://user-images.githubusercontent.com/18377109/166409453-f958a464-4570-4d31-b334-7739e61634ef.png) |  ![Screenshot from 2022-05-03 11-17-05](https://user-images.githubusercontent.com/18377109/166409469-423155b1-cb7f-4a6c-adb6-93d6a3ffa752.png) |







