### PR TITLE
Implementing the remaining sections of Help page

### DIFF
--- a/src/Pages/Help/Changelog.elm
+++ b/src/Pages/Help/Changelog.elm
@@ -70,10 +70,9 @@ content =
     Markdown.toHtml [ class "markdown" ] """
 
 ## Version 1.0.0
-- Majority of the build. See: [https://github.com/xbmc/elm-chorus/commits/main]
+- Majority of the build. See: https://github.com/xbmc/elm-chorus/commits/main
 - Many features from Chorus 2 have been incorporated.
 
-[https://github.com/xbmc/elm-chorus/commits/main]:https://github.com/xbmc/elm-chorus/commits/main
 
 """
 

--- a/src/Pages/Help/Changelog.elm
+++ b/src/Pages/Help/Changelog.elm
@@ -2,8 +2,12 @@ module Pages.Help.Changelog exposing (Model, Msg, Params, page)
 
 import Colors
 import Components.VerticalNavHelp
-import Element exposing (column, fill, fillPortion, row, spacingXY)
+import Element exposing (..)
 import Element.Background as Background
+import Element.Font as Font
+import Html exposing (Html)
+import Html.Attributes exposing (class)
+import Markdown exposing (..)
 import Spa.Document exposing (Document)
 import Spa.Generated.Route exposing (Route)
 import Spa.Page as Page exposing (Page)
@@ -58,6 +62,23 @@ subscriptions model =
 
 
 
+-- Markdown
+
+
+content : Html msg
+content =
+    Markdown.toHtml [ class "markdown" ] """
+
+## Version 1.0.0
+- Majority of the build. See: [https://github.com/xbmc/elm-chorus/commits/main]
+- Many features from Chorus 2 have been incorporated.
+
+[https://github.com/xbmc/elm-chorus/commits/main]:https://github.com/xbmc/elm-chorus/commits/main
+
+"""
+
+
+
 -- VIEW
 
 
@@ -65,9 +86,12 @@ view : Model -> Document Msg
 view model =
     { title = "Help.Changelog"
     , body =
-        Components.VerticalNavHelp.view
-            model.route
-            ++ [ column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.background ]
-                    []
-               ]
+        [ row [ Element.height fill, Element.width fill ]
+            [ column [ Element.height fill, Element.width (fillPortion 3), scrollbarY ] (Components.VerticalNavHelp.view model.route)
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.white, padding 40 ]
+                [ el [ Font.color (rgb255 0 0 0) ] (Element.html content)
+                ]
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.greyscaleMercury, padding 40 ] []
+            ]
+        ]
     }

--- a/src/Pages/Help/Developers.elm
+++ b/src/Pages/Help/Developers.elm
@@ -2,8 +2,12 @@ module Pages.Help.Developers exposing (Model, Msg, Params, page)
 
 import Colors
 import Components.VerticalNavHelp
-import Element exposing (column, fill, fillPortion, row, spacingXY)
+import Element exposing (..)
 import Element.Background as Background
+import Element.Font as Font
+import Html exposing (Html)
+import Html.Attributes exposing (class)
+import Markdown exposing (..)
 import Spa.Document exposing (Document)
 import Spa.Generated.Route exposing (Route)
 import Spa.Page as Page exposing (Page)
@@ -58,6 +62,75 @@ subscriptions model =
 
 
 
+-- Markdown
+
+
+content : Html msg
+content =
+    Markdown.toHtml [ class "markdown" ] """
+
+# Developers information
+
+Do you want to help with making Chorus even better? Find help below...
+
+This page contains information about getting your dev environment up and running so you can build and test 
+
+your changes without the hassle of setting up all the required dependencies.
+
+## Developing elm chorus
+
+To develop elm-chorus, you must have the following:
+
+** For MacOS, Windows, Linux **
+- Kodi application
+- Chrome/Chromium, Firefox
+- Elm
+- NPM
+
+### Installing Kodi Application
+
+You can refer to this [guide] in order to install the application and run the following commands:
+
+~~~
+sudo apt install software-properties-common
+
+sudo add-apt-repository -y ppa:team-xbmc/ppa
+
+sudo apt install kodi
+~~~
+
+** For NPM ** : you can checkout the [official website].
+
+** For Elm ** : you can refer to this[ guide] in order to install Elm.
+
+### Building/Running the Project
+
+Firstly, make sure that you have Kodi application running in the background, then run the following commands:
+
+~~~
+git clone https://github.com/xbmc/elm-chorus.git
+
+cd elm-chorus/
+
+npm start
+~~~
+and point your browser to http://localhost:1234 by default or whatever port Node tells you.
+
+## Committing your changes
+
+As a rule of thumb, you should use elm-format in order to format the Elm files in which you have made the changes and Prettier for JS, CSS, etc. 
+
+before pushing it.
+
+** **
+
+[official website]:https://nodejs.org/en/
+[guide]: https://kodi.wiki/view/HOW-TO:Install_Kodi_for_Linux
+[ guide]: https://guide.elm-lang.org/install/elm.html
+"""
+
+
+
 -- VIEW
 
 
@@ -65,9 +138,12 @@ view : Model -> Document Msg
 view model =
     { title = "Help.Developers"
     , body =
-        Components.VerticalNavHelp.view
-            model.route
-            ++ [ column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.background ]
-                    []
-               ]
+        [ row [ Element.height fill, Element.width fill ]
+            [ column [ Element.height fill, Element.width (fillPortion 3), scrollbarY ] (Components.VerticalNavHelp.view model.route)
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.white, padding 40 ]
+                [ el [ Font.color (rgb255 0 0 0) ] (Element.html content)
+                ]
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.greyscaleMercury, padding 40 ] []
+            ]
+        ]
     }

--- a/src/Pages/Help/Readme.elm
+++ b/src/Pages/Help/Readme.elm
@@ -2,8 +2,12 @@ module Pages.Help.Readme exposing (Model, Msg, Params, page)
 
 import Colors
 import Components.VerticalNavHelp
-import Element exposing (column, fill, fillPortion, row, spacingXY)
+import Element exposing (..)
 import Element.Background as Background
+import Element.Font as Font
+import Html exposing (Html)
+import Html.Attributes exposing (class)
+import Markdown exposing (..)
 import Spa.Document exposing (Document)
 import Spa.Generated.Route exposing (Route)
 import Spa.Page as Page exposing (Page)
@@ -58,6 +62,129 @@ subscriptions model =
 
 
 
+-- Markdown
+
+
+content : Html msg
+content =
+    Markdown.toHtml [ class "markdown" ] """
+
+# Kodi Web Interface - Elm Chorus
+
+The default Web Interface for Kodi.
+
+A great modern Web UI for Kodi. Browse your Music, Movies or TV Shows from the comfort of your own web 
+
+browser. You can play media via Kodi or stream it in your browser. Works best with Chrome but plays well with 
+
+most modern browsers.
+
+Successor to [Chorus2]. A complete rebuild using Elm.
+
+##  Author
+
+[Alex Ionkov] with help from [these kind people].
+
+## Current state
+In Elm-Chorus, the basic layout and functionality from Chorus 2 has already been implemented but it still lacks some features,
+
+styling and layout pages. Still considered in-development project, expect bugs, changes, nuclear war,etc.
+
+## Feature requests / Bugs
+
+Add them to the list. For bugs please include Kodi version, Web browser version, Chorus version and any errors 
+
+that display in the console. For feature requests, checkout the API browser to see if your request is currently 
+
+possible.
+
+## Streaming
+
+Disclaimer: The success of this depends on the file formats vs what the browser supports. In general most things 
+
+work.
+
+### Audio streaming
+
+In the top right there are some tabs, two of them are named Kodi and Local, this is how you toggle what player 
+
+the UI is controlling. In Local mode the logo and accents are pinky-red, In Kodi mode the logo is the Kodi blue. 
+
+When you are in a given mode, actions affect that player, so if you click Play on a track when in Local mode, it will 
+
+play through the browser, likewise, when in Kodi mode all commands are sent to Kodi. You can also add media to 
+
+other playlists by clicking the menu buttons (three dots vertical) on most media items.
+
+### Video streaming
+
+Video streaming via HTML5 "sort of" works, it really depends on the codec used. An embedded VLC player is also 
+
+available with better codec support. This looks like the best we can get until Kodi supports transcoding. **Chrome** 
+
+**users: ** Chrome has removed support for vlc/divx plugins so streaming a video requires a [Chrome friendly codec]. 
+
+For best results use Chrome with mp4 video that has 2 channel audio (5.1 audio doesn't seem to work).
+
+## Kodi settings via the web interface
+
+You can change most of the settings you would find in Kodi via the settings page in the web interface. Some 
+
+settings have been omitted as they require interaction with the GUI and others are just a basic text field with no 
+
+options.
+
+## Contributing
+
+If you would like to make this project better I would appreciate any help. You can do pull requests against the 
+
+main branch. See the [developers] section for information about getting a dev environment up and running the project.
+
+### Translations
+
+At the moment, there are a handful of languages available but more can be easily added. More strings are always being
+
+added so always consider english as the source of truth. So if you see something in english but want it in your language, 
+
+I need you! To contribute, send us a Pull request or if you don't know git, a link to the language file.
+
+_English is the only real complete translation file so start with that as your base_.
+
+## Donate
+
+Are you a fan of Chorus? You can buy Alex a beer to say thanks :)
+
+## License
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License 
+
+as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later 
+
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the 
+
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public 
+
+License for more details.
+
+You should have received a copy of the GNU General Public License [along with this program]; if not, write to the 
+
+Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+[Click here for more information] .
+
+[Click here for more information]: https://github.com/xbmc/chorus2/blob/master/src/lang/en/license.md
+[along with this program]: https://github.com/xbmc/chorus2/blob/master/LICENSE
+[developers]: http://localhost:1234/help/developers
+[Chrome friendly codec]: https://en.wikipedia.org/wiki/HTML5_video#Browser_support
+[Alex Ionkov]: https://ionkov.com/
+[these kind people]: https://github.com/xbmc/elm-chorus/graphs/contributors
+[Chorus2]: https://github.com/xbmc/chorus2
+"""
+
+
+
 -- VIEW
 
 
@@ -65,9 +192,12 @@ view : Model -> Document Msg
 view model =
     { title = "Help.Readme"
     , body =
-        Components.VerticalNavHelp.view
-            model.route
-            ++ [ column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.background ]
-                    []
-               ]
+        [ row [ Element.height fill, Element.width fill ]
+            [ column [ Element.height fill, Element.width (fillPortion 3), scrollbarY ] (Components.VerticalNavHelp.view model.route)
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.white, padding 40 ]
+                [ el [ Font.color (rgb255 0 0 0) ] (Element.html content)
+                ]
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.greyscaleMercury, padding 40 ] []
+            ]
+        ]
     }

--- a/src/Pages/Help/Translations.elm
+++ b/src/Pages/Help/Translations.elm
@@ -2,8 +2,12 @@ module Pages.Help.Translations exposing (Model, Msg, Params, page)
 
 import Colors
 import Components.VerticalNavHelp
-import Element exposing (column, fill, fillPortion, row, spacingXY)
+import Element exposing (..)
 import Element.Background as Background
+import Element.Font as Font
+import Html exposing (Html)
+import Html.Attributes exposing (class)
+import Markdown exposing (..)
 import Spa.Document exposing (Document)
 import Spa.Generated.Route exposing (Route)
 import Spa.Page as Page exposing (Page)
@@ -58,6 +62,28 @@ subscriptions model =
 
 
 
+-- Markdown
+
+
+content : Html msg
+content =
+    Markdown.toHtml [ class "markdown" ] """
+
+# Translations
+
+To update the language files you just need to know a bit of GIT. This page should help with the structure of 
+
+language files.
+
+## Submitting an update
+
+Send a pull request through [GitHub] on a new branch is the best way. Would consider updates via other methods.
+
+[Github]: https://github.com/xbmc/elm-chorus
+"""
+
+
+
 -- VIEW
 
 
@@ -65,9 +91,12 @@ view : Model -> Document Msg
 view model =
     { title = "Help.Translations"
     , body =
-        Components.VerticalNavHelp.view
-            model.route
-            ++ [ column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.background ]
-                    []
-               ]
+        [ row [ Element.height fill, Element.width fill ]
+            [ column [ Element.height fill, Element.width (fillPortion 3), scrollbarY ] (Components.VerticalNavHelp.view model.route)
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.white, padding 40 ]
+                [ el [ Font.color (rgb255 0 0 0) ] (Element.html content)
+                ]
+            , column [ Element.height fill, Element.width (fillPortion 6), spacingXY 5 7, Background.color Colors.greyscaleMercury, padding 40 ] []
+            ]
+        ]
     }


### PR DESCRIPTION
Hi @razzeee,
I have implemented the changelog section of the Help page. In this PR, I will push the code for the remaining sections - Readme, Developers, and Translations as well.

| Sections | Chorus 2 | Elm Chorus |
| ------------- | ------------- | ------------- |
| Changelog  | ![Screenshot from 2022-05-06 14-27-24](https://user-images.githubusercontent.com/18377109/167101114-1facbe2d-7b86-450b-8246-8cc8337183e5.png) | ![Screenshot from 2022-05-06 14-28-09](https://user-images.githubusercontent.com/18377109/167101356-d907fd55-fbf5-40b3-b5b7-21ba0b4a6c21.png) |
| Developers | ![Screenshot from 2022-05-06 18-35-08](https://user-images.githubusercontent.com/18377109/167137220-838d2887-1423-4e5f-9412-52ee0a7e1991.png) | ![Screenshot from 2022-05-06 18-35-18](https://user-images.githubusercontent.com/18377109/167137278-6b0db236-cb52-4174-851a-1e714e1acc6a.png) |
| Readme | ![Screenshot from 2022-05-06 22-34-58](https://user-images.githubusercontent.com/18377109/167179540-0f0f2da7-e479-4c35-ae1f-ddcd8f32cca4.png) | ![Screenshot from 2022-05-06 22-35-16](https://user-images.githubusercontent.com/18377109/167179555-a071fa63-0fc8-4b6d-80ac-be859c230a03.png) |
| Translations | ![Screenshot from 2022-05-06 22-38-16](https://user-images.githubusercontent.com/18377109/167180692-5426ca64-33a4-43e4-a497-0e13296b44fa.png) | ![Screenshot from 2022-05-06 22-38-27](https://user-images.githubusercontent.com/18377109/167180715-a6288bfb-072b-481e-bbbf-76f965203323.png) |










