### PR TITLE
Implemented Seasonid_int page

### DIFF
--- a/src/Components/SectionHeader.elm
+++ b/src/Components/SectionHeader.elm
@@ -1,4 +1,4 @@
-module Components.SectionHeader exposing (view, viewAlbums, viewArtists, viewMovies, viewSeasons, viewTvShows, viewVideos)
+module Components.SectionHeader exposing (view, viewAlbums, viewArtists, viewEpisode, viewMovies, viewSeasons, viewTvShows, viewVideos)
 
 import Colors exposing (cardHover)
 import Element as Element exposing (Attribute, Element, alignBottom, alignLeft, alignRight, alignTop, centerX, centerY, clipX, column, el, fill, fillPortion, height, image, maximum, minimum, mouseOver, padding, paddingEach, paddingXY, px, rgb, row, spacingXY, width, wrappedRow)
@@ -13,7 +13,7 @@ import Material.Icons.Types as MITypes exposing (Icon)
 import Spa.Generated.Route as Route exposing (Route)
 import Url exposing (percentDecode, percentEncode)
 import Url.Builder exposing (crossOrigin)
-import WSDecoder exposing (AlbumObj, ArtistObj, ItemDetails, MovieObj, SeasonObj, SongObj, TvshowObj, VideoObj)
+import WSDecoder exposing (AlbumObj, ArtistObj, EpisodeObj, ItemDetails, MovieObj, SeasonObj, SongObj, TvshowObj, VideoObj)
 
 
 view : String -> Maybe msg -> Bool -> List { title : String, action : Maybe msg } -> Element msg
@@ -287,8 +287,8 @@ viewTvShows buttonMsg tvshow =
         ]
 
 
-viewSeasons : msg -> SeasonObj -> Element msg
-viewSeasons buttonMsg season =
+viewSeasons : Int -> msg -> SeasonObj -> Element msg
+viewSeasons tvshowid buttonMsg season =
     column
         [ Background.color (rgb 1 1 1)
         , Element.htmlAttribute (Html.Attributes.class "card-parent")
@@ -316,12 +316,52 @@ viewSeasons buttonMsg season =
             , el [ alignBottom, padding 10 ] (materialButtonBig ( Filled.play_arrow, buttonMsg )) -- TODO: make it functional once EpisodeObjs have been created
             ]
         , Element.link [ Element.width fill, Element.height fill, alignBottom, paddingEach { left = 10, right = 0, top = 10, bottom = 10 }, Font.color Colors.black ]
-            { url = "" --- TODO : redirect url to seasonid_int page when it gets implemented
+            { url = Route.toString (Route.Tvshows__Seasons__Seasonid_Int { tvshowid = tvshowid, seasonid = season.seasonid }) --- TODO : redirect url to seasonid_int page when it gets implemented
             , label =
                 column []
                     [ Element.text season.label
                     , el [ paddingEach { left = 0, right = 0, top = 5, bottom = 0 }, Font.color Colors.greyscaleGray, Font.size 13 ]
                         (Element.text (String.fromInt season.episode ++ " episodes"))
+                    ]
+            }
+        ]
+
+
+viewEpisode : msg -> EpisodeObj -> Element msg
+viewEpisode buttonMsg episode =
+    column
+        [ Background.color (rgb 1 1 1)
+        , Element.height (fill |> minimum 140 |> maximum 190)
+        , Element.width (fill |> minimum 280 |> maximum 280)
+        , Element.htmlAttribute (Html.Attributes.class "card-parent")
+        , Element.htmlAttribute (Html.Attributes.style "box-shadow" "0px 8px 6px -10px #888888")
+        ]
+        [ case episode.poster of
+            "" ->
+                image [ width fill, height (px 135) ]
+                    { src = "/thumbnail_default.png"
+                    , description = "Hero Image"
+                    }
+
+            _ ->
+                image [ width fill, height (px 135) ]
+                    { src = crossOrigin "http://localhost:8080" [ "image", percentEncode episode.poster ] []
+                    , description = "Thumbnail"
+                    }
+        , column [ Element.htmlAttribute (Html.Attributes.class "card"), Element.height (px 135), Element.width (px 280), Background.color cardHover ]
+            [ row [ alignTop, alignRight, paddingXY 0 10 ]
+                [ materialButton ( Filled.check_box_outline_blank, buttonMsg )
+                , materialButton ( Filled.thumb_up, buttonMsg )
+                , materialButtonBig ( Filled.more_vert, buttonMsg )
+                ]
+            , el [ alignBottom, padding 10 ] (materialButtonBig ( Filled.play_arrow, buttonMsg ))
+            ]
+        , Element.link [ Element.width fill, Element.height fill, alignBottom, paddingEach { left = 10, right = 0, top = 10, bottom = 10 }, Font.color Colors.black ]
+            { url = "" -- TODO : redirect this link to episodeid_int page when it gets implemented
+            , label =
+                column [ spacingXY 0 10 ]
+                    [ Element.text episode.title
+                    , el [ Font.color Colors.greyscaleGray, Font.size 13 ] (Element.text ("Episode " ++ String.fromInt episode.episode))
                     ]
             }
         ]

--- a/src/Components/SectionHeader.elm
+++ b/src/Components/SectionHeader.elm
@@ -1,4 +1,4 @@
-module Components.SectionHeader exposing (view, viewAlbums, viewArtists, viewMovies, viewTvShows, viewVideos)
+module Components.SectionHeader exposing (view, viewAlbums, viewArtists, viewMovies, viewSeasons, viewTvShows, viewVideos)
 
 import Colors exposing (cardHover)
 import Element as Element exposing (Attribute, Element, alignBottom, alignLeft, alignRight, alignTop, centerX, centerY, clipX, column, el, fill, fillPortion, height, image, maximum, minimum, mouseOver, padding, paddingEach, paddingXY, px, rgb, row, spacingXY, width, wrappedRow)
@@ -13,7 +13,7 @@ import Material.Icons.Types as MITypes exposing (Icon)
 import Spa.Generated.Route as Route exposing (Route)
 import Url exposing (percentDecode, percentEncode)
 import Url.Builder exposing (crossOrigin)
-import WSDecoder exposing (AlbumObj, ArtistObj, ItemDetails, MovieObj, SongObj, TvshowObj, VideoObj)
+import WSDecoder exposing (AlbumObj, ArtistObj, ItemDetails, MovieObj, SeasonObj, SongObj, TvshowObj, VideoObj)
 
 
 view : String -> Maybe msg -> Bool -> List { title : String, action : Maybe msg } -> Element msg
@@ -276,12 +276,52 @@ viewTvShows buttonMsg tvshow =
             , el [ alignBottom, padding 10 ] (materialButtonBig ( Filled.play_arrow, buttonMsg ))
             ]
         , Element.link [ Element.width fill, Element.height fill, alignBottom, paddingEach { left = 10, right = 0, top = 10, bottom = 10 }, Font.color Colors.black ]
-            { url = "" -- TODO : direct the link towards the individual tvshow page once the routing has been implemented
+            { url = Route.toString (Route.Tvshows__Tvshowid_Int { tvshowid = tvshow.tvshowid })
             , label =
                 column []
                     [ Element.text tvshow.label
                     , el [ paddingEach { left = 0, right = 0, top = 5, bottom = 0 }, Font.color Colors.greyscaleGray, Font.size 13 ]
                         (Element.text (String.slice 0 3 (String.fromFloat tvshow.rating)))
+                    ]
+            }
+        ]
+
+
+viewSeasons : msg -> SeasonObj -> Element msg
+viewSeasons buttonMsg season =
+    column
+        [ Background.color (rgb 1 1 1)
+        , Element.htmlAttribute (Html.Attributes.class "card-parent")
+        , Element.height (fill |> maximum 310)
+        , Element.width (fill |> minimum 170 |> maximum 170)
+        , Element.htmlAttribute (Html.Attributes.style "box-shadow" "0px 0px 2px #888888")
+        ]
+        [ case season.poster of
+            "" ->
+                image [ alignTop, width fill, height fill ]
+                    { src = "/thumbnail_default.png"
+                    , description = "Default thumbnail"
+                    }
+
+            _ ->
+                image [ alignTop, width fill, height fill ]
+                    { src = crossOrigin "http://localhost:8080" [ "image", percentEncode season.poster ] []
+                    , description = "Poster"
+                    }
+        , column [ Element.htmlAttribute (Html.Attributes.class "card"), Element.height (px 255), Element.width (fill |> minimum 170 |> maximum 170), Background.color cardHover ]
+            [ row [ alignTop, alignRight, paddingXY 0 10 ]
+                [ materialButton ( Filled.check_box_outline_blank, buttonMsg ) -- TODO : checkbox to Set Watched
+                , materialButtonBig ( Filled.more_vert, buttonMsg ) -- TODO : Add Dropdown
+                ]
+            , el [ alignBottom, padding 10 ] (materialButtonBig ( Filled.play_arrow, buttonMsg )) -- TODO: make it functional once EpisodeObjs have been created
+            ]
+        , Element.link [ Element.width fill, Element.height fill, alignBottom, paddingEach { left = 10, right = 0, top = 10, bottom = 10 }, Font.color Colors.black ]
+            { url = "" --- TODO : redirect url to seasonid_int page when it gets implemented
+            , label =
+                column []
+                    [ Element.text season.label
+                    , el [ paddingEach { left = 0, right = 0, top = 5, bottom = 0 }, Font.color Colors.greyscaleGray, Font.size 13 ]
+                        (Element.text (String.fromInt season.episode ++ " episodes"))
                     ]
             }
         ]

--- a/src/Pages/Tvshows/Recent.elm
+++ b/src/Pages/Tvshows/Recent.elm
@@ -61,7 +61,7 @@ type alias Model =
 init : Shared.Model -> Url Params -> ( Model, Cmd Msg )
 init shared url =
     ( { currentlyPlaying = shared.currentlyPlaying, tvshow_list = shared.tvshow_list, route = url.route }
-    , sendAction """{"jsonrpc": "2.0", "method": "VideoLibrary.GetTvshows", "params": { "filter": {"field": "playcount", "operator": "is", "value": "0"}, "properties" : ["art", "rating", "thumbnail", "playcount", "file","year","dateadded"], "sort": { "order": "ascending", "method": "label", "ignorearticle": true } }, "id": "libTvshows"}"""
+    , sendAction """{"jsonrpc": "2.0", "method": "VideoLibrary.GetTvshows", "params": { "filter": {"field": "playcount", "operator": "is", "value": "0"}, "properties" : ["art", "rating", "thumbnail", "playcount", "file","year","dateadded","mpaa","genre","season","studio","episode","watchedepisodes","plot","cast"], "sort": { "order": "ascending", "method": "label", "ignorearticle": true } }, "id": "libTvshows"}"""
     )
 
 

--- a/src/Pages/Tvshows/Tvshowid_Int.elm
+++ b/src/Pages/Tvshows/Tvshowid_Int.elm
@@ -1,0 +1,215 @@
+module Pages.Tvshows.Tvshowid_Int exposing (Model, Msg, Params, page)
+
+import Colors exposing (black, cardHover, darkGreyIcon, greyIcon, white, whiteIcon)
+import Components.SectionHeader
+import Element exposing (..)
+import Element.Background as Background
+import Element.Font as Font exposing (Font)
+import Element.Input as Input
+import Html.Attributes exposing (..)
+import Material.Icons as Filled
+import Material.Icons.Types as MITypes exposing (Icon)
+import Request
+import Shared exposing (sendActions)
+import Spa.Document exposing (Document)
+import Spa.Generated.Route as Route exposing (Route)
+import Spa.Page as Page exposing (Page)
+import Spa.Url as Url exposing (Url)
+import Url exposing (percentEncode)
+import Url.Builder exposing (crossOrigin)
+import WSDecoder exposing (ArtistObj, SeasonObj, TvshowObj, VideoObj)
+
+
+page : Page Params Model Msg
+page =
+    Page.application
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        , save = save
+        , load = load
+        }
+
+
+type Msg
+    = ReplaceMe
+
+
+type alias Params =
+    { tvshowid : Int }
+
+
+type alias Model =
+    { tvshowid : Int
+    , tvshow : Maybe TvshowObj
+    , tvshow_list : List TvshowObj
+    , season_list : List SeasonObj
+    }
+
+
+init : Shared.Model -> Url Params -> ( Model, Cmd Msg )
+init shared { params } =
+    ( { tvshowid = params.tvshowid, tvshow = getTvShow params.tvshowid shared.tvshow_list, tvshow_list = shared.tvshow_list, season_list = shared.season_list }
+    , sendActions [ """{"jsonrpc": "2.0", "method": "VideoLibrary.GetSeasons", "params": {"tvshowid": """ ++ String.fromInt params.tvshowid ++ """ ,"properties":["season","episode","tvshowid","art"]}, "id": "libSeasons"}""" ]
+    )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        ReplaceMe ->
+            ( model, Cmd.none )
+
+
+save : Model -> Shared.Model -> Shared.Model
+save model shared =
+    { shared | season_list = model.season_list }
+
+
+load : Shared.Model -> Model -> ( Model, Cmd Msg )
+load shared model =
+    ( { model | season_list = shared.season_list }, Cmd.none )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+
+getTvShow : Int -> List TvshowObj -> Maybe TvshowObj
+getTvShow id tvShowlist =
+    List.head (List.filter (\tvshow -> id == tvshow.tvshowid) tvShowlist)
+
+
+
+-- VIEWS
+
+
+view : Model -> Document Msg
+view model =
+    { title = "TvShow_Int"
+    , body =
+        [ case model.tvshow of
+            Nothing ->
+                column [ Element.height fill, Element.width fill ]
+                    [ Element.text (String.fromInt model.tvshowid)
+                    ]
+
+            Just tvshow ->
+                column [ Element.height fill, Element.width fill, Background.color Colors.sidebar ]
+                    [ row [ Element.height (fillPortion 1), Element.width fill, Background.color (Element.rgba255 50 53 55 1), Element.htmlAttribute (Html.Attributes.class "card-parent"), paddingXY 20 15 ]
+                        [ column [ Element.width (px 250), Element.height (px 250), Element.htmlAttribute (Html.Attributes.class "card-parent"), alignTop ]
+                            [ case tvshow.thumbnail of
+                                "" ->
+                                    image [ Element.height (fill |> maximum 250), Element.width (fillPortion 2 |> maximum 240) ]
+                                        { src = "/thumbnail_default.png"
+                                        , description = "Default Thumbnail"
+                                        }
+
+                                _ ->
+                                    image [ Element.height (fill |> maximum 360), Element.width (fillPortion 2 |> maximum 240) ]
+                                        { src = crossOrigin "http://localhost:8080" [ "image", percentEncode tvshow.thumbnail ] []
+                                        , description = "Thumbnail"
+                                        }
+                            , column [ Element.htmlAttribute (Html.Attributes.class "card"), Element.height (px 360), Element.width (fill |> minimum 230 |> maximum 240), Background.color cardHover ]
+                                [ row [ alignTop, alignRight, paddingXY 15 15 ]
+                                    [ Input.button []
+                                        { onPress = Nothing
+                                        , label = Element.html (Filled.thumb_up 25 (MITypes.Color <| Colors.whiteIcon))
+                                        }
+                                    ]
+                                , el [ htmlAttribute (Html.Attributes.style "margin" "auto"), paddingEach { top = 0, left = 0, right = 0, bottom = 50 } ]
+                                    (Input.button []
+                                        { onPress = Nothing
+                                        , label = Element.html (Filled.play_arrow 45 (MITypes.Color <| Colors.whiteIcon))
+                                        }
+                                    )
+                                ]
+                            ]
+                        , column [ alignTop, Element.height fill, Element.width (fillPortion 7 |> maximum 900), paddingXY 10 35 ]
+                            [ row [ alignRight, alignTop, Font.size 25, Element.htmlAttribute (Html.Attributes.style "position" "absolute") ] [ Element.text (String.slice 0 3 (String.fromFloat tvshow.rating)), Element.html (Filled.star 36 (MITypes.Color <| greyIcon)) ]
+                            , row [] [ el [ Font.color white, Font.size 30 ] (Element.text tvshow.label), el [ alignBottom, paddingXY 10 0, Font.size 15 ] (Element.text (String.fromInt tvshow.year)) ]
+                            , column [ paddingEach { top = 20, left = 0, right = 0, bottom = 0 }, spacingXY 0 12, Font.size 14 ]
+                                [ row []
+                                    [ el [ Font.color white ] (Element.text "Genre: ")
+                                    , row []
+                                        (List.map
+                                            (\genre ->
+                                                Element.text (genre ++ " ")
+                                            )
+                                            tvshow.genre
+                                        )
+                                    ]
+                                , row []
+                                    [ el [ Font.color white ] (Element.text "Studio: ")
+                                    , row []
+                                        (List.map
+                                            (\studio ->
+                                                Element.text (studio ++ " ")
+                                            )
+                                            tvshow.studio
+                                        )
+                                    ]
+                                , row []
+                                    [ el [ Font.color white ] (Element.text "Cast: ")
+                                    , row []
+                                        (List.map
+                                            (\cast ->
+                                                Element.text (cast.name ++ ", ")
+                                            )
+                                            (List.take 5 tvshow.cast)
+                                        )
+                                    ]
+                                , row [] [ el [ Font.color white ] (Element.text "Rated: "), Element.text tvshow.mpaa ]
+                                , row [] [ el [ Font.color white ] (Element.text "Episodes: "), Element.text (String.fromInt tvshow.episode ++ " total" ++ " " ++ "(" ++ String.fromInt (tvshow.episode - tvshow.watchepisode) ++ " unwatched)") ]
+                                , paragraph [ Element.height (fill |> minimum 105), Element.width (fill |> maximum 950), spacing 10, paddingXY 0 20 ] [ Element.text tvshow.plot ]
+                                ]
+                            , row [ spacingXY 10 0 ]
+                                [ Input.button [ paddingXY 12 8, Background.color Colors.navTextHover ]
+                                    { onPress = Nothing -- TODO : make it functional once EpisodeObj have been created
+                                    , label = row [] [ el [ Font.color white, paddingEach { top = 0, left = 0, right = 10, bottom = 0 } ] (Element.text "Play"), Element.html (Filled.play_circle_filled 16 (MITypes.Color <| whiteIcon)) ]
+                                    }
+                                , Input.button [ paddingXY 12 8, Background.color (Element.rgba255 71 74 75 1) ]
+                                    { onPress = Nothing -- TODO : make it functional once EpisodeObj have been created
+                                    , label = row [] [ el [ Font.color white, paddingEach { top = 0, left = 0, right = 10, bottom = 0 } ] (Element.text "Queue"), Element.html (Filled.add_circle 16 (MITypes.Color <| greyIcon)) ]
+                                    }
+                                , Input.button [ paddingXY 12 8, Background.color (Element.rgba255 71 74 75 1) ]
+                                    { onPress = Nothing -- TODO : Button to set Watched
+                                    , label = row [] [ el [ Font.color white, paddingEach { top = 0, left = 0, right = 10, bottom = 0 } ] (Element.text "Set Watched"), Element.html (Filled.check_box 16 (MITypes.Color <| greyIcon)) ]
+                                    }
+                                , Input.button [ paddingXY 12 8, Background.color (Element.rgba255 71 74 75 1) ]
+                                    { onPress = Nothing -- TODO : Add More menu dropdown
+                                    , label = row [] [ el [ Font.color white, paddingEach { top = 0, left = 0, right = 10, bottom = 0 } ] (Element.text "More"), Element.html (Filled.more_vert 16 (MITypes.Color <| greyIcon)) ]
+                                    }
+                                ]
+                            ]
+                        ]
+                    , column [ Element.height (fillPortion 5), Element.width fill, paddingXY 35 35, spacingXY 5 7 ]
+                        [ wrappedRow [ spacingXY 15 0 ]
+                            (List.map
+                                (\season ->
+                                    Components.SectionHeader.viewSeasons ReplaceMe season
+                                )
+                                model.season_list
+                            )
+                        ]
+                    , case tvshow.fanart of
+                        "" ->
+                            column [ Element.htmlAttribute (Html.Attributes.class "image-gradient"), alignRight, alignTop ]
+                                [ image [ Element.width (fillPortion 2 |> maximum 740) ]
+                                    { src = "/concert.jpg"
+                                    , description = "Default-Fanart"
+                                    }
+                                ]
+
+                        _ ->
+                            column [ Element.htmlAttribute (Html.Attributes.class "image-gradient"), alignRight, alignTop ]
+                                [ image [ Element.width (fillPortion 2 |> maximum 740) ]
+                                    { src = crossOrigin "http://localhost:8080" [ "image", percentEncode tvshow.fanart ] []
+                                    , description = "Fanart"
+                                    }
+                                ]
+                    ]
+        ]
+    }

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -36,7 +36,7 @@ import Spa.Generated.Route as Route exposing (Route)
 import Time
 import Translations
 import Url exposing (Url)
-import WSDecoder exposing (AlbumObj, ArtistObj, Connection(..), FileObj, ItemDetails, LeftSidebarMenuHover(..), LocalPlaylists, LocalSettings, MovieObj, PType(..), ParamsResponse, PlayerObj(..), PlaylistObj, ResultResponse(..), SettingsObj, SongObj, SourceObj, TvshowObj, VideoObj, decodeLocalSettings, getMediaType, localPlaylistDecoder, localPlaylistEncoder, paramsResponseDecoder, resultResponseDecoder)
+import WSDecoder exposing (AlbumObj, ArtistObj, Connection(..), FileObj, ItemDetails, LeftSidebarMenuHover(..), LocalPlaylists, LocalSettings, MovieObj, PType(..), ParamsResponse, PlayerObj(..), PlaylistObj, ResultResponse(..), SeasonObj, SettingsObj, SongObj, SourceObj, TvshowObj, VideoObj, decodeLocalSettings, getMediaType, localPlaylistDecoder, localPlaylistEncoder, paramsResponseDecoder, resultResponseDecoder)
 
 
 
@@ -92,6 +92,7 @@ type alias Model =
     , interfaceLocalSettings : LocalSettings
     , addonLocalSettings : LocalSettings
     , tabSwitch : SharedType.Tabs
+    , season_list : List SeasonObj
     }
 
 
@@ -291,6 +292,7 @@ init flags url key =
       , tvshow_list = []
       , source_list = []
       , file_list = []
+      , season_list = []
       , volumeSlider =
             SingleSlider.init
                 { min = 0
@@ -325,7 +327,7 @@ init flags url key =
         , """{"jsonrpc": "2.0", "method": "AudioLibrary.GetArtists", "params": { "properties": [ "thumbnail", "fanart", "born", "formed", "died", "disbanded", "yearsactive", "mood", "style", "genre" ] }, "id": 1}"""
         , """{"jsonrpc": "2.0", "method": "VideoLibrary.GetMusicVideos", "params": { "properties": [ "title", "thumbnail", "artist", "album", "genre", "lastplayed", "year", "runtime", "fanart", "file", "streamdetails","dateadded" ] }, "id": "libMusicVideos"}"""
         , """{"jsonrpc": "2.0", "method": "VideoLibrary.GetMovies", "params": { "properties" : ["art", "rating", "thumbnail", "playcount", "file","year","dateadded","genre","director","cast","streamdetails","mpaa","runtime","writer"] }, "id": "libMovies"}"""
-        , """{"jsonrpc": "2.0", "method": "VideoLibrary.GetTVShows", "params": { "properties": ["art", "genre", "plot", "title", "originaltitle", "year", "rating", "thumbnail", "playcount", "file", "fanart","dateadded","year"] }, "id": "libTvShows"}"""
+        , """{"jsonrpc": "2.0", "method": "VideoLibrary.GetTVShows", "params": { "properties": ["art", "genre", "plot", "title", "originaltitle", "year", "rating", "thumbnail", "playcount", "file", "fanart","dateadded","year","mpaa","genre","season","studio","episode","watchedepisodes","cast"] }, "id": "libTvShows"}"""
         , """{"jsonrpc": "2.0", "method": "Files.GetSources", "params": { "media": "video" }, "id": 1 }""" --get video and music sources
         , """{"jsonrpc": "2.0", "method": "Files.GetSources", "params": { "media": "music" }, "id": 1 }"""
         , """{"jsonrpc": "2.0", "method": "Player.SetShuffle", "params": { "playerid": 0, "shuffle": false }, "id": 1 }""" --set shuffle to false on init
@@ -630,6 +632,9 @@ update msg model =
 
                 ResultN tvshowList ->
                     ( { model | tvshow_list = tvshowList }, Cmd.none )
+
+                ResultO seasonList ->
+                    ( { model | season_list = seasonList }, Cmd.none )
 
         ToggleRightSidebar ->
             ( { model | rightSidebarExtended = not model.rightSidebarExtended }

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -36,7 +36,7 @@ import Spa.Generated.Route as Route exposing (Route)
 import Time
 import Translations
 import Url exposing (Url)
-import WSDecoder exposing (AlbumObj, ArtistObj, Connection(..), FileObj, ItemDetails, LeftSidebarMenuHover(..), LocalPlaylists, LocalSettings, MovieObj, PType(..), ParamsResponse, PlayerObj(..), PlaylistObj, ResultResponse(..), SeasonObj, SettingsObj, SongObj, SourceObj, TvshowObj, VideoObj, decodeLocalSettings, getMediaType, localPlaylistDecoder, localPlaylistEncoder, paramsResponseDecoder, resultResponseDecoder)
+import WSDecoder exposing (AlbumObj, ArtistObj, Connection(..), EpisodeObj, FileObj, ItemDetails, LeftSidebarMenuHover(..), LocalPlaylists, LocalSettings, MovieObj, PType(..), ParamsResponse, PlayerObj(..), PlaylistObj, ResultResponse(..), SeasonObj, SettingsObj, SongObj, SourceObj, TvshowObj, VideoObj, decodeLocalSettings, getMediaType, localPlaylistDecoder, localPlaylistEncoder, paramsResponseDecoder, resultResponseDecoder)
 
 
 
@@ -93,6 +93,7 @@ type alias Model =
     , addonLocalSettings : LocalSettings
     , tabSwitch : SharedType.Tabs
     , season_list : List SeasonObj
+    , episode_list : List EpisodeObj
     }
 
 
@@ -293,6 +294,7 @@ init flags url key =
       , source_list = []
       , file_list = []
       , season_list = []
+      , episode_list = []
       , volumeSlider =
             SingleSlider.init
                 { min = 0
@@ -635,6 +637,9 @@ update msg model =
 
                 ResultO seasonList ->
                     ( { model | season_list = seasonList }, Cmd.none )
+
+                ResultP episodeList ->
+                    ( { model | episode_list = episodeList }, Cmd.none )
 
         ToggleRightSidebar ->
             ( { model | rightSidebarExtended = not model.rightSidebarExtended }

--- a/src/Spa/Generated/Pages.elm
+++ b/src/Spa/Generated/Pages.elm
@@ -51,6 +51,7 @@ import Pages.Thumbsup
 import Pages.Top
 import Pages.Tvshows
 import Pages.Tvshows.Recent
+import Pages.Tvshows.Seasons.Seasonid_Int
 import Pages.Tvshows.Tvshowid_Int
 import Pages.Videoplayer.Movieid_Int
 import Shared
@@ -109,6 +110,7 @@ type Model
     | Music__Videos__Videoid_Int__Model Pages.Music.Videos.Videoid_Int.Model
     | Music__Genre__Genre_String__Model Pages.Music.Genre.Genre_String.Model
     | Tvshows__Tvshowid_Int__Model Pages.Tvshows.Tvshowid_Int.Model
+    | Tvshows__Seasons__Seasonid_Int__Model Pages.Tvshows.Seasons.Seasonid_Int.Model
 
 
 type Msg
@@ -156,6 +158,7 @@ type Msg
     | Music__Videos__Videoid_Int__Msg Pages.Music.Videos.Videoid_Int.Msg
     | Music__Genre__Genre_String__Msg Pages.Music.Genre.Genre_String.Msg
     | Tvshows__Tvshowid_Int__Msg Pages.Tvshows.Tvshowid_Int.Msg
+    | Tvshows__Seasons__Seasonid_Int__Msg Pages.Tvshows.Seasons.Seasonid_Int.Msg
 
 
 
@@ -297,6 +300,9 @@ init route =
         Route.Tvshows__Tvshowid_Int params ->
             pages.tvshows__tvshowid_int.init params
 
+        Route.Tvshows__Seasons__Seasonid_Int params ->
+            pages.tvshows__seasons__seasonid_int.init params
+
 
 
 -- UPDATE
@@ -436,6 +442,9 @@ update bigMsg bigModel =
 
         ( Tvshows__Tvshowid_Int__Msg msg, Tvshows__Tvshowid_Int__Model model ) ->
             pages.tvshows__tvshowid_int.update msg model
+
+        ( Tvshows__Seasons__Seasonid_Int__Msg msg, Tvshows__Seasons__Seasonid_Int__Model model ) ->
+            pages.tvshows__seasons__seasonid_int.update msg model
 
         _ ->
             ( bigModel, Cmd.none )
@@ -580,6 +589,9 @@ bundle bigModel =
         Tvshows__Tvshowid_Int__Model model ->
             pages.tvshows__tvshowid_int.bundle model
 
+        Tvshows__Seasons__Seasonid_Int__Model model ->
+            pages.tvshows__seasons__seasonid_int.bundle model
+
 
 view : Model -> Document Msg
 view model =
@@ -690,6 +702,7 @@ pages :
     , music__videos__videoid_int : Upgraded Pages.Music.Videos.Videoid_Int.Params Pages.Music.Videos.Videoid_Int.Model Pages.Music.Videos.Videoid_Int.Msg
     , music__genre__genre_string : Upgraded Pages.Music.Genre.Genre_String.Params Pages.Music.Genre.Genre_String.Model Pages.Music.Genre.Genre_String.Msg
     , tvshows__tvshowid_int : Upgraded Pages.Tvshows.Tvshowid_Int.Params Pages.Tvshows.Tvshowid_Int.Model Pages.Tvshows.Tvshowid_Int.Msg
+    , tvshows__seasons__seasonid_int : Upgraded Pages.Tvshows.Seasons.Seasonid_Int.Params Pages.Tvshows.Seasons.Seasonid_Int.Model Pages.Tvshows.Seasons.Seasonid_Int.Msg
     }
 pages =
     { top = Pages.Top.page |> upgrade Top__Model Top__Msg
@@ -736,4 +749,5 @@ pages =
     , music__videos__videoid_int = Pages.Music.Videos.Videoid_Int.page |> upgrade Music__Videos__Videoid_Int__Model Music__Videos__Videoid_Int__Msg
     , music__genre__genre_string = Pages.Music.Genre.Genre_String.page |> upgrade Music__Genre__Genre_String__Model Music__Genre__Genre_String__Msg
     , tvshows__tvshowid_int = Pages.Tvshows.Tvshowid_Int.page |> upgrade Tvshows__Tvshowid_Int__Model Tvshows__Tvshowid_Int__Msg
+    , tvshows__seasons__seasonid_int = Pages.Tvshows.Seasons.Seasonid_Int.page |> upgrade Tvshows__Seasons__Seasonid_Int__Model Tvshows__Seasons__Seasonid_Int__Msg
     }

--- a/src/Spa/Generated/Pages.elm
+++ b/src/Spa/Generated/Pages.elm
@@ -51,6 +51,7 @@ import Pages.Thumbsup
 import Pages.Top
 import Pages.Tvshows
 import Pages.Tvshows.Recent
+import Pages.Tvshows.Tvshowid_Int
 import Pages.Videoplayer.Movieid_Int
 import Shared
 import Spa.Document as Document exposing (Document)
@@ -107,6 +108,7 @@ type Model
     | Music__Artist__Artistid_Int__Model Pages.Music.Artist.Artistid_Int.Model
     | Music__Videos__Videoid_Int__Model Pages.Music.Videos.Videoid_Int.Model
     | Music__Genre__Genre_String__Model Pages.Music.Genre.Genre_String.Model
+    | Tvshows__Tvshowid_Int__Model Pages.Tvshows.Tvshowid_Int.Model
 
 
 type Msg
@@ -153,6 +155,7 @@ type Msg
     | Music__Artist__Artistid_Int__Msg Pages.Music.Artist.Artistid_Int.Msg
     | Music__Videos__Videoid_Int__Msg Pages.Music.Videos.Videoid_Int.Msg
     | Music__Genre__Genre_String__Msg Pages.Music.Genre.Genre_String.Msg
+    | Tvshows__Tvshowid_Int__Msg Pages.Tvshows.Tvshowid_Int.Msg
 
 
 
@@ -291,6 +294,9 @@ init route =
         Route.Music__Genre__Genre_String params ->
             pages.music__genre__genre_string.init params
 
+        Route.Tvshows__Tvshowid_Int params ->
+            pages.tvshows__tvshowid_int.init params
+
 
 
 -- UPDATE
@@ -427,6 +433,9 @@ update bigMsg bigModel =
 
         ( Music__Videos__Videoid_Int__Msg msg, Music__Videos__Videoid_Int__Model model ) ->
             pages.music__videos__videoid_int.update msg model
+
+        ( Tvshows__Tvshowid_Int__Msg msg, Tvshows__Tvshowid_Int__Model model ) ->
+            pages.tvshows__tvshowid_int.update msg model
 
         _ ->
             ( bigModel, Cmd.none )
@@ -568,6 +577,9 @@ bundle bigModel =
         Music__Genre__Genre_String__Model model ->
             pages.music__genre__genre_string.bundle model
 
+        Tvshows__Tvshowid_Int__Model model ->
+            pages.tvshows__tvshowid_int.bundle model
+
 
 view : Model -> Document Msg
 view model =
@@ -677,6 +689,7 @@ pages :
     , music__artist__artistid_int : Upgraded Pages.Music.Artist.Artistid_Int.Params Pages.Music.Artist.Artistid_Int.Model Pages.Music.Artist.Artistid_Int.Msg
     , music__videos__videoid_int : Upgraded Pages.Music.Videos.Videoid_Int.Params Pages.Music.Videos.Videoid_Int.Model Pages.Music.Videos.Videoid_Int.Msg
     , music__genre__genre_string : Upgraded Pages.Music.Genre.Genre_String.Params Pages.Music.Genre.Genre_String.Model Pages.Music.Genre.Genre_String.Msg
+    , tvshows__tvshowid_int : Upgraded Pages.Tvshows.Tvshowid_Int.Params Pages.Tvshows.Tvshowid_Int.Model Pages.Tvshows.Tvshowid_Int.Msg
     }
 pages =
     { top = Pages.Top.page |> upgrade Top__Model Top__Msg
@@ -722,4 +735,5 @@ pages =
     , music__artist__artistid_int = Pages.Music.Artist.Artistid_Int.page |> upgrade Music__Artist__Artistid_Int__Model Music__Artist__Artistid_Int__Msg
     , music__videos__videoid_int = Pages.Music.Videos.Videoid_Int.page |> upgrade Music__Videos__Videoid_Int__Model Music__Videos__Videoid_Int__Msg
     , music__genre__genre_string = Pages.Music.Genre.Genre_String.page |> upgrade Music__Genre__Genre_String__Model Music__Genre__Genre_String__Msg
+    , tvshows__tvshowid_int = Pages.Tvshows.Tvshowid_Int.page |> upgrade Tvshows__Tvshowid_Int__Model Tvshows__Tvshowid_Int__Msg
     }

--- a/src/Spa/Generated/Route.elm
+++ b/src/Spa/Generated/Route.elm
@@ -52,6 +52,7 @@ type Route
     | Music__Artist__Artistid_Int { artistid : Int }
     | Music__Videos__Videoid_Int { videoid : Int }
     | Music__Genre__Genre_String { genre : String }
+    | Tvshows__Tvshowid_Int { tvshowid : Int }
 
 
 fromUrl : Url -> Maybe Route
@@ -119,6 +120,9 @@ routes =
         , (Parser.s "music" </> Parser.s "videos" </> Parser.int)
             |> Parser.map (\videoid -> { videoid = videoid })
             |> Parser.map Music__Videos__Videoid_Int
+        , (Parser.s "tvshows" </> Parser.int)
+            |> Parser.map (\tvshowid -> { tvshowid = tvshowid })
+            |> Parser.map Tvshows__Tvshowid_Int
         ]
 
 
@@ -256,6 +260,9 @@ toString route =
 
                 Music__Genre__Genre_String { genre } ->
                     [ "music", "genre", genre ]
+
+                Tvshows__Tvshowid_Int { tvshowid } ->
+                    [ "tvshows", String.fromInt tvshowid ]
     in
     segments
         |> String.join "/"

--- a/src/Spa/Generated/Route.elm
+++ b/src/Spa/Generated/Route.elm
@@ -8,6 +8,10 @@ import Url exposing (Url)
 import Url.Parser as Parser exposing ((</>), Parser)
 
 
+type alias Season =
+    { tvshowid : Int, seasonid : Int }
+
+
 type Route
     = Top
     | Addons
@@ -53,6 +57,7 @@ type Route
     | Music__Videos__Videoid_Int { videoid : Int }
     | Music__Genre__Genre_String { genre : String }
     | Tvshows__Tvshowid_Int { tvshowid : Int }
+    | Tvshows__Seasons__Seasonid_Int { tvshowid : Int, seasonid : Int }
 
 
 fromUrl : Url -> Maybe Route
@@ -123,6 +128,9 @@ routes =
         , (Parser.s "tvshows" </> Parser.int)
             |> Parser.map (\tvshowid -> { tvshowid = tvshowid })
             |> Parser.map Tvshows__Tvshowid_Int
+        , (Parser.s "tvshows" </> Parser.int </> Parser.int)
+            |> Parser.map Season
+            |> Parser.map Tvshows__Seasons__Seasonid_Int
         ]
 
 
@@ -263,6 +271,9 @@ toString route =
 
                 Tvshows__Tvshowid_Int { tvshowid } ->
                     [ "tvshows", String.fromInt tvshowid ]
+
+                Tvshows__Seasons__Seasonid_Int { tvshowid, seasonid } ->
+                    [ "tvshows", String.fromInt tvshowid, String.fromInt seasonid ]
     in
     segments
         |> String.join "/"

--- a/src/WSDecoder.elm
+++ b/src/WSDecoder.elm
@@ -1,4 +1,4 @@
-module WSDecoder exposing (AlbumObj, ArtistObj, Connection(..), DefaultElement, FileObj, FileType(..), Item, ItemDetails, LeftSidebarMenuHover(..), LocalPlaylists, LocalSettings, MovieObj, Option, PType(..), ParamsResponse, Path, PlayerObj(..), PlaylistObj, ResultResponse(..), SeasonObj, SettingDefault(..), SettingsObj, SongObj, SourceObj, TvshowObj, VideoObj, decodeLocalSettings, encodeLocalSettings, getMediaType, localPlaylistDecoder, localPlaylistEncoder, paramsResponseDecoder, prepareDownloadDecoder, resultResponseDecoder, stringInDefaultElementToString)
+module WSDecoder exposing (AlbumObj, ArtistObj, Connection(..), DefaultElement, EpisodeObj, FileObj, FileType(..), Item, ItemDetails, LeftSidebarMenuHover(..), LocalPlaylists, LocalSettings, MovieObj, Option, PType(..), ParamsResponse, Path, PlayerObj(..), PlaylistObj, ResultResponse(..), SeasonObj, SettingDefault(..), SettingsObj, SongObj, SourceObj, TvshowObj, VideoObj, decodeLocalSettings, encodeLocalSettings, getMediaType, localPlaylistDecoder, localPlaylistEncoder, paramsResponseDecoder, prepareDownloadDecoder, resultResponseDecoder, stringInDefaultElementToString)
 
 import Json.Decode as Decode exposing (Decoder, at, bool, float, int, list, nullable, string)
 import Json.Decode.Pipeline exposing (custom, optional, required)
@@ -191,6 +191,7 @@ type ResultResponse
     | ResultM (List VideoObj)
     | ResultN (List TvshowObj)
     | ResultO (List SeasonObj)
+    | ResultP (List EpisodeObj)
 
 
 
@@ -275,6 +276,7 @@ queryDecoder =
         , videoQueryDecoder
         , tvShowQueryDecoder
         , seasonQueryDecoder
+        , episodeQueryDecoder
         ]
 
 
@@ -766,6 +768,7 @@ seasonDecoder =
         |> required "episode" int
         |> required "tvshowid" int
         |> custom (at [ "art", "poster" ] string)
+        |> required "watchedepisodes" int
 
 
 type alias MovieObj =
@@ -815,6 +818,34 @@ type alias SeasonObj =
     , episode : Int
     , tvshowid : Int
     , poster : String
+    , watchedepisode : Int
+    }
+
+
+episodeQueryDecoder : Decoder ResultResponse
+episodeQueryDecoder =
+    Decode.succeed ResultP
+        |> custom (at [ "result", "episodes" ] (list episodeDecoder))
+
+
+episodeDecoder : Decoder EpisodeObj
+episodeDecoder =
+    Decode.succeed EpisodeObj
+        |> required "label" string
+        |> required "episode" int
+        |> required "seasonid" int
+        |> required "tvshowid" int
+        |> custom (at [ "art", "thumb" ] string)
+        |> required "title" string
+
+
+type alias EpisodeObj =
+    { label : String
+    , episode : Int
+    , seasonid : Int
+    , tvshowid : Int
+    , poster : String
+    , title : String
     }
 
 

--- a/src/WSDecoder.elm
+++ b/src/WSDecoder.elm
@@ -1,4 +1,4 @@
-module WSDecoder exposing (AlbumObj, ArtistObj, Connection(..), DefaultElement, FileObj, FileType(..), Item, ItemDetails, LeftSidebarMenuHover(..), LocalPlaylists, LocalSettings, MovieObj, Option, PType(..), ParamsResponse, Path, PlayerObj(..), PlaylistObj, ResultResponse(..), SettingDefault(..), SettingsObj, SongObj, SourceObj, TvshowObj, VideoObj, decodeLocalSettings, encodeLocalSettings, getMediaType, localPlaylistDecoder, localPlaylistEncoder, paramsResponseDecoder, prepareDownloadDecoder, resultResponseDecoder, stringInDefaultElementToString)
+module WSDecoder exposing (AlbumObj, ArtistObj, Connection(..), DefaultElement, FileObj, FileType(..), Item, ItemDetails, LeftSidebarMenuHover(..), LocalPlaylists, LocalSettings, MovieObj, Option, PType(..), ParamsResponse, Path, PlayerObj(..), PlaylistObj, ResultResponse(..), SeasonObj, SettingDefault(..), SettingsObj, SongObj, SourceObj, TvshowObj, VideoObj, decodeLocalSettings, encodeLocalSettings, getMediaType, localPlaylistDecoder, localPlaylistEncoder, paramsResponseDecoder, prepareDownloadDecoder, resultResponseDecoder, stringInDefaultElementToString)
 
 import Json.Decode as Decode exposing (Decoder, at, bool, float, int, list, nullable, string)
 import Json.Decode.Pipeline exposing (custom, optional, required)
@@ -190,6 +190,7 @@ type ResultResponse
     | ResultL (List SettingsObj)
     | ResultM (List VideoObj)
     | ResultN (List TvshowObj)
+    | ResultO (List SeasonObj)
 
 
 
@@ -273,6 +274,7 @@ queryDecoder =
         , settingsQueryDecoder
         , videoQueryDecoder
         , tvShowQueryDecoder
+        , seasonQueryDecoder
         ]
 
 
@@ -739,6 +741,31 @@ tvShowDecoder =
         |> required "dateadded" string
         |> required "rating" Decode.float
         |> custom (at [ "art", "poster" ] string)
+        |> required "genre" (list string)
+        |> required "mpaa" string
+        |> required "plot" string
+        |> required "season" int
+        |> required "studio" (list string)
+        |> required "episode" int
+        |> required "watchedepisodes" int
+        |> required "cast" (list castDecoder)
+        |> custom (at [ "art", "fanart" ] string)
+
+
+seasonQueryDecoder : Decoder ResultResponse
+seasonQueryDecoder =
+    Decode.succeed ResultO
+        |> custom (at [ "result", "seasons" ] (list seasonDecoder))
+
+
+seasonDecoder : Decoder SeasonObj
+seasonDecoder =
+    Decode.succeed SeasonObj
+        |> required "label" string
+        |> required "seasonid" int
+        |> required "episode" int
+        |> required "tvshowid" int
+        |> custom (at [ "art", "poster" ] string)
 
 
 type alias MovieObj =
@@ -770,6 +797,24 @@ type alias TvshowObj =
     , dateadded : String
     , rating : Float
     , thumbnail : String
+    , genre : List String
+    , mpaa : String
+    , plot : String
+    , season : Int
+    , studio : List String
+    , episode : Int
+    , watchepisode : Int
+    , cast : List CastObj
+    , fanart : String
+    }
+
+
+type alias SeasonObj =
+    { label : String
+    , seasonid : Int
+    , episode : Int
+    , tvshowid : Int
+    , poster : String
     }
 
 


### PR DESCRIPTION
Hi @razzeee,
I have created and implemented the `seasonid_int` page. I have worked on its routing, created an `EpisodeObj`, modified decoder of `SeasonObj`, created new decoders from scratch for `EpisodeObj`, and `viewEpisode` card. Please let me know if any changes are required.

Also, there are unrelated commits as this current PR’s branch is the sub-branch of this [PR](https://github.com/xbmc/elm-chorus/pull/129). Once the `tvshowid_int` page gets merged, I will rebase this PR and remove unrelated commits.

![Screenshot from 2022-08-15 18-51-05](https://user-images.githubusercontent.com/18377109/184643083-a408e9c9-7e54-4f6b-9cbf-fd383345766a.png)

